### PR TITLE
refactor(@comma/ds): `next/image` dependency 이슈로 `Image` 컴포넌트 분리

### DIFF
--- a/packages/ds/elements/Button/index.tsx
+++ b/packages/ds/elements/Button/index.tsx
@@ -1,12 +1,11 @@
-import Image, { StaticImageData } from 'next/image';
-
 import type * as Stitches from '@stitches/react';
 import { Variants } from 'framer-motion';
 
+import { Image, ImageProps } from '../Image';
 import * as S from './styled';
 
 interface ButtonProps extends Stitches.VariantProps<typeof S.ButtonElement> {
-  icon?: string | StaticImageData;
+  icon?: ImageProps['src'];
   loading?: boolean;
   disabled?: boolean;
   fullWidth?: boolean;

--- a/packages/ds/elements/Image/index.tsx
+++ b/packages/ds/elements/Image/index.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+
+import type { ImageProps as NextImageProps, StaticImageData } from 'next/image';
+
+export type NextImageElement = React.ForwardRefExoticComponent<NextImageProps>;
+
+export type ImageProps =
+  | React.ImgHTMLAttributes<HTMLImageElement>
+  | NextImageProps;
+
+export type ImageElementType = 'img' | undefined | typeof import('next/image');
+
+export const Image: React.FC<ImageProps> = (props) => {
+  function __isNextStaticRequire(
+    src: ImageProps['src']
+  ): src is { default: StaticImageData } {
+    return typeof src !== 'string' && Object.hasOwn(src || {}, 'default');
+  }
+
+  function __isNextProps(
+    element: ImageElementType,
+    props: ImageProps
+  ): props is NextImageProps {
+    return element !== 'img' && props.src !== undefined;
+  }
+
+  const __getTypeSafeProps = (
+    props: ImageProps
+  ):
+    | { isNext: true; props: NextImageProps }
+    | { isNext: false; props: React.ImgHTMLAttributes<HTMLImageElement> } => {
+    if (__isNextProps(element, props)) {
+      return {
+        isNext: true,
+        props: {
+          ...props,
+          src: __isNextStaticRequire(props.src)
+            ? props.src.default.src
+            : props.src,
+        },
+      };
+    }
+
+    return { isNext: false, props };
+  };
+
+  const [element, setElement] = useState<ImageElementType>();
+  const [typeSafeProps] = useState(__getTypeSafeProps(props));
+  const { isNext, props: __props } = typeSafeProps;
+
+  useEffect(() => {
+    const __loadElement = async () => {
+      try {
+        setElement(await import('next/image'));
+      } catch (error) {
+        setElement('img');
+      }
+    };
+
+    __loadElement();
+  }, []);
+
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  if (!element) return <React.Fragment />;
+
+  if (isNext && element !== 'img')
+    return React.createElement(element.default, __props);
+  else if (!isNext && element === 'img')
+    return React.createElement(element, __props);
+
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <React.Fragment />;
+};

--- a/packages/ds/elements/index.ts
+++ b/packages/ds/elements/index.ts
@@ -1,1 +1,2 @@
 export * from './Button';
+export * from './Image';

--- a/packages/ds/package.json
+++ b/packages/ds/package.json
@@ -2,8 +2,6 @@
   "name": "@comma/ds",
   "version": "0.0.1",
   "description": "comma design system",
-  "main": "src/index.ts",
-  "module": "src/index.ts",
   "sideEffects": false,
   "dependencies": {
     "@stitches/react": "^1.2.8",


### PR DESCRIPTION
## 🔍 What is this PR?
#8 이슈를 해결했어요

기존 `@comma/ds` 패키지에서는 next/image의 `Image` 컴포넌트를 기반으로 작성되어 있어, Next.js 환경이 아닌 React 환경에서 호출 시, 에러가 발생했던 이슈를 해결했어요


## 🙇 Changes
- 추후 재사용을 고려해 새로운 `Image` 컴포넌트를 작성했어요
    > 프로젝트에 따라 `<img/>`/`<Image/>`를 구분해 호출할 필요 없이 자동으로 Next.js/React 환경을 구분해요
- 새로 추가된 `<Image/>` 컴포넌트에 맞춰 기존에 작성되어있던 `<Button/>` 컴포넌트 Props도 수정했어요

## ✅ 체크 리스트
- [x] `@comma/ds` Button 컴포넌트 호출 후, React/Next.js 구동 여부 확인
  ```tsx
  import { Button } from "@comma/ds";
  
  <Button icon="src" />
  ```